### PR TITLE
fixed yaml-linting when $dir contains more then 1 yml-file

### DIFF
--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -89,7 +89,7 @@ final class LintCommand extends Command
         }
 		
 		// yaml only supports one file at a time
-		$succeeded = $this->syncFindExec(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*'], ['vendor/bin/yaml-lint']);
+		$succeed = $this->syncFindExec(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*'], ['vendor/bin/yaml-lint']);
 		
 		if (!$succeed) {
 			$style->section('YAML checks');

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -32,7 +32,7 @@ final class LintCommand extends Command
         $processes[] = [
             self::ERR_YAML,
             'YAML checks',
-            $this->asyncProc(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*', '-exec', 'vendor/bin/yaml-lint', '{}', '+']),
+            $this->asyncProc(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*', '-exec', 'vendor/bin/yaml-lint', '{}', ';']),
         ];
         $processes[] = [
             self::ERR_PHP,

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -89,7 +89,7 @@ final class LintCommand extends Command
             }
         }
 
-        // yaml only supports one file at a time
+        // yaml-lint only supports one file at a time
         $label = 'YAML checks';
         $succeed = $this->syncFindExec(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*'], ['vendor/bin/yaml-lint']);
 

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -107,7 +107,7 @@ final class LintCommand extends Command
 		$processes = array();
 
         $process = new Process($findCmd);
-        $process->mustRun(function($type, $buffer) use ($processes, $execCmd) {
+        $process->mustRun(function($type, $buffer) use (&$processes, $execCmd) {
 			if (Process::ERR === $type) {				
 				throw new Exception($buffer);
 			} else {

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -24,15 +24,17 @@ final class LintCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+		// some lecture on "find -exec vs. find | xargs"
+		// https://www.everythingcli.org/find-exec-vs-find-xargs/
         $style = new SymfonyStyle($input, $output);
-        // the "+" on "find ... -exec" makes the find command fail, when the -exec'ed command fails.
         $dir = $input->getArgument('dir');
 
         $processes = [];
+		// yaml only supports one file at a time, therefore we use xargs
         $processes[] = [
             self::ERR_YAML,
             'YAML checks',
-            $this->asyncProc(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*', '-print0', '|', 'xargs', '-0', '-n1', 'vendor/bin/yaml-lint', '{}', ';']),
+            $this->asyncProc(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*', '-print0', '|', 'xargs', '-0', '-n1', 'vendor/bin/yaml-lint']),
         ];
         $processes[] = [
             self::ERR_PHP,

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -32,7 +32,7 @@ final class LintCommand extends Command
         $processes[] = [
             self::ERR_YAML,
             'YAML checks',
-            $this->asyncProc(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*', '-exec', 'vendor/bin/yaml-lint', '{}', ';']),
+            $this->asyncProc(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*', '-print0', '|', 'xargs', '-0', '-n1', 'vendor/bin/yaml-lint', '{}', ';']),
         ];
         $processes[] = [
             self::ERR_PHP,

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -89,6 +89,7 @@ final class LintCommand extends Command
         }
 		
 		// yaml only supports one file at a time
+		$label = 'YAML checks';
 		$succeed = $this->syncFindExec(['find', $dir, '-type', 'f', '-name', '*.yml', '!', '-path', '*/vendor/*'], ['vendor/bin/yaml-lint']);
 		
 		if (!$succeed) {

--- a/tests/succeed/default.config.yml
+++ b/tests/succeed/default.config.yml
@@ -1,0 +1,83 @@
+setup: true
+debug:
+    enabled: false
+    throw_always_exception: false # `true` for all error levels, `[E_WARNING, E_NOTICE]` for subset
+instname: null
+server: https://www.redaxo.org/
+servername: REDAXO
+error_email: null
+fileperm: '0664'
+dirperm: '0775'
+session_duration: 7200
+session_keep_alive: 21600
+# using separate cookie domains for frontend and backend is more secure,
+# but be warned that some features like detecting a backend user in the frontend
+# will no longer work.
+session:
+    backend:
+        cookie:
+            lifetime: null
+            path: null
+            domain: null
+            secure: null
+            httponly: true
+            samesite: 'Strict'
+    frontend:
+        cookie:
+            lifetime: null
+            path: null
+            domain: null
+            secure: null
+            httponly: true
+            samesite: 'Strict'
+password_policy:
+    length: {min: 8, max: 4096}
+    lowercase: {min: 0}
+    uppercase: {min: 0}
+    digit: {min: 0}
+lang: de_de
+lang_fallback: [en_gb, de_de]
+use_https: false
+use_hsts: false
+use_gzip: true
+use_etag: true
+use_last_modified: false
+start_page: structure
+timezone: Europe/Berlin
+socket_proxy: null
+setup_addons:
+    - backup
+    - be_style
+system_addons:
+    - backup
+    - mediapool
+    - structure
+    - metainfo
+    - be_style
+    - media_manager
+    - users
+    - install
+    - project
+table_prefix: rex_
+temp_prefix: tmp_
+db:
+    1:
+        host: localhost
+        login: root
+        password: ''
+        name: redaxo_5_0
+        persistent: false
+    2:
+        host: ''
+        login: ''
+        password: ''
+        name: ''
+        persistent: false
+use_accesskeys: true
+accesskeys:
+    save: s
+    apply: x
+    delete: d
+    add: a
+    add_2: y
+editor: null


### PR DESCRIPTION
we try to reproduce a travis build error regarding yaml-lint

> yaml-lint 1.1.3, symfony/yaml v4.2.8: multiple input files currently unsupported

https://travis-ci.org/FriendsOfREDAXO/minibar/jobs/514001403

Background
"find -exec vs. find | xargs"
https://www.everythingcli.org/find-exec-vs-find-xargs/