### PR TITLE
fix bash script path

### DIFF
--- a/bin/lint-file.sh
+++ b/bin/lint-file.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env sh
 
-BASEDIR=$(dirname $0)
+BASEDIR=$(dirname $0)/..
+
+if [ ! -d "$BASEDIR/vendor" ]
+then
+    BASEDIR=$BASEDIR/../../..
+fi
 
 ## wrapper bash file which allows to pass a filepath to lint-query
 
 echo "$1"
 
-cat "$1" | $BASEDIR/../vendor/bin/lint-query
+cat "$1" | $BASEDIR/vendor/bin/lint-query

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -52,7 +52,7 @@ final class LintCommand extends Command
         $processes[] = [
             self::ERR_SQL,
             'SQL checks',
-            $this->asyncProc(['find', $dir, '-name', '*.sql', '!', '-path', '*/vendor/*', '-exec',  $rootPath.'/bin/lint-file.sh', '{}', '+']),
+            $this->asyncProc(['find', $dir, '-name', '*.sql', '!', '-path', '*/vendor/*', '-exec',  __DIR__.'/../../bin/lint-file.sh', '{}', '+']),
         ];
 
         // $this->syncProc(['npm', 'install', 'csslint']);


### PR DESCRIPTION
Erkennung im Bashfile `lint-file.sh` wo der vendor/bin Ordner zu finden ist (vgl. #33).

Korrektur des Pfads zum Bashfile, da dieses immer im Linter Ordner liegt und nicht im vendor/bin Ordner.