### PR TITLE
Exclude .idea

### DIFF
--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -42,7 +42,7 @@ final class LintCommand extends Command
         $processes[] = [
             self::ERR_PHP,
             'PHP checks',
-            $this->asyncProc([$rootPath.'/vendor/bin/parallel-lint', '--exclude', 'vendor', $dir]),
+            $this->asyncProc([$rootPath.'/vendor/bin/parallel-lint', '--exclude', 'vendor', '--exclude', '.idea', $dir]),
         ];
         $processes[] = [
             self::ERR_JSON,

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -37,7 +37,7 @@ final class LintCommand extends Command
         // https://www.everythingcli.org/find-exec-vs-find-xargs/
 
         $style = new SymfonyStyle($input, $output);
-        $dir = $input->getArgument('dir');
+        $dir = rtrim($input->getArgument('dir'), DIRECTORY_SEPARATOR);
 
         $processes[] = [
             self::ERR_PHP,

--- a/lib/Command/LintCommand.php
+++ b/lib/Command/LintCommand.php
@@ -42,7 +42,7 @@ final class LintCommand extends Command
         $processes[] = [
             self::ERR_PHP,
             'PHP checks',
-            $this->asyncProc([$rootPath.'/vendor/bin/parallel-lint', '--exclude', 'vendor', '--exclude', '.idea', $dir]),
+            $this->asyncProc([$rootPath.'/vendor/bin/parallel-lint', '--exclude', $dir.'/vendor', '--exclude', $dir.'/.idea', $dir]),
         ];
         $processes[] = [
             self::ERR_JSON,

--- a/tests/succeed/.idea/fileTemplates/internal/PHP Class.php
+++ b/tests/succeed/.idea/fileTemplates/internal/PHP Class.php
@@ -1,0 +1,13 @@
+<?php
+#parse("PHP File Header.php")
+
+#if (${NAMESPACE})
+
+namespace ${NAMESPACE};
+
+#end
+
+#parse("PHP Class Doc Comment.php")
+class ${NAME} {
+
+}


### PR DESCRIPTION
phpstorm template dateien mit php endung sind in der regel nicht in gültiger php syntax