### PR TITLE
allow php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
 
 script:
+  # remove ignore-platform-req after all dependencies are php8 compatible
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "8.0" ]]; then composer install; fi;
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer install --ignore-platform-req=php; fi;
   # negative tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,21 @@ language: php
 
 php:
   - '7.1'
+  - '8.0'
 
 before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
 
 script:
-  - composer install
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "8.0" ]]; then composer install; fi;
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer install --ignore-platform-req=php; fi;
   # negative tests
   - php bin/rexlint tests/fail/yml/   > /dev/null 2>&1 ; lintstatus=$?; if [ $lintstatus -ne  1 ]; then echo "expected fail, got $lintstatus" && exit 50; fi
   - php bin/rexlint tests/fail/php/   > /dev/null 2>&1 ; lintstatus=$?; if [ $lintstatus -ne  2 ]; then echo "expected fail, got $lintstatus" && exit 50; fi
   - php bin/rexlint tests/fail/json/  > /dev/null 2>&1 ; lintstatus=$?; if [ $lintstatus -ne  4 ]; then echo "expected fail, got $lintstatus" && exit 50; fi
   - php bin/rexlint tests/fail/sql/   > /dev/null 2>&1 ; lintstatus=$?; if [ $lintstatus -ne 16 ]; then echo "expected fail, got $lintstatus" && exit 50; fi
   - php bin/rexlint tests/fail/mixed/ > /dev/null 2>&1 ; lintstatus=$?; if [ $lintstatus -ne  7 ]; then echo "expected fail, got $lintstatus" && exit 50; fi
-  
+
   # positive tests
   - php bin/rexlint tests/succeed/
   - cd / && php $TRAVIS_BUILD_DIR/bin/rexlint $TRAVIS_BUILD_DIR/tests/succeed/

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
 
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "seld/jsonlint": "^1.7",
         "j13k/yaml-lint": "^1.1",
         "php-parallel-lint/php-parallel-lint": "^1.1",


### PR DESCRIPTION
Man kann es trotzdem noch nicht mit php8 nutzen, da es von phpmyadmin/sql-parser noch keine kompatible Version gibt.
Aber ich denke, wir können es von unserer Seite aus trotzdem schon kompatibel zu php8 markieren.
Sobald es dann von phpmyadmin/sql-parser eine kompatible Version gibt, brauchen wir hier nix weiter zu tun. Außer es wäre ein Major-Update.