### PR TITLE
Exclude vendor and .idea recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
-vendor/
+/node_modules/
+/vendor/
 .php_cs.cache
 composer.lock

--- a/tests/succeed/sub/subsub/vendor/invalid.php
+++ b/tests/succeed/sub/subsub/vendor/invalid.php
@@ -1,0 +1,3 @@
+<?php
+
+invalid invalid


### PR DESCRIPTION
Bei den anderen Checks (json etc.) excluden wird auch rekursiv (per `*/vendor/*`).
parallel-lint braucht aber scheinbar spezifische pfade. deswegen suche ich selbst rekursiv nach den ordnern.